### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "Pod::TreeWalker",
+    "license"     : "Artistic-2.0",
     "version"     : "0.0.3",
     "author"      : "Dave Rolsky <autarch@urth.org>",
     "description" : "Walk a Pod tree and generate an event for each node",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license